### PR TITLE
fix(image): 将失效的 img.nga.178.com 域名迁移至 img.nga.cn

### DIFF
--- a/html/topic-spic.js
+++ b/html/topic-spic.js
@@ -13,12 +13,21 @@ vsPostMessage('setTitle', {
   title: document.title
 });
 
+function normalizeNGAImageUrl(url) {
+  if (!url) {
+    return url;
+  }
+  return url
+    .replace('://img.nga.178.com', '://img.nga.cn')
+    .replace('://img4.nga.178.com', '://img4.nga.cn');
+}
+
 // 无图模式：点击占位加载当前图片
 document.querySelectorAll('.nga-img-placeholder').forEach((el) => {
   el.style.cursor = 'pointer';
   el.title = '点击加载图片';
   el.onclick = () => {
-    const src = el.dataset['src'];
+    const src = normalizeNGAImageUrl(el.dataset['src']);
     if (!src) {
       return;
     }
@@ -37,6 +46,11 @@ document.querySelectorAll('.nga-img-placeholder').forEach((el) => {
 
 // 给图片添加查看图片的功能
 document.querySelectorAll('img').forEach((img) => {
+  const normalizedSrc = normalizeNGAImageUrl(img.src);
+  if (normalizedSrc && normalizedSrc !== img.src) {
+    img.src = normalizedSrc;
+  }
+
   img.onload = () => {
     console.log(img);
     AutoResizeImage(40, 40, img);
@@ -64,7 +78,7 @@ document.querySelectorAll('img').forEach((img) => {
 const supportImageTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
 supportImageTypes.forEach((type) => {
   document.querySelectorAll(`.topic-content a[href$=".${type}"]`).forEach((a) => {
-    a.dataset['imageSrc'] = a.href;
+    a.dataset['imageSrc'] = normalizeNGAImageUrl(a.href);
     // vsc中 return false 不能阻止a标签跳转。曲线救国
     a.href = 'javascript:;';
     a.onclick = () => {
@@ -116,40 +130,44 @@ function onSubmit() {
 }
 
 function Resize(Ratio, objImg) {
-  var img = new Image();
-  img.src = objImg.src;
-  var w = img.width;
-  var h = img.height;
+  var w = objImg.naturalWidth || objImg.width;
+  var h = objImg.naturalHeight || objImg.height;
+  if (!w || !h) {
+    return;
+  }
   w = w * Ratio;
   h = h * Ratio;
-  console.log(Ratio, img.width, img.height, w, h);
+  console.log(Ratio, w, h);
   objImg.height = h;
   objImg.width = w;
 }
 
 function AutoResizeImage(maxWidth, maxHeight, objImg) {
-  var img = new Image();
-  img.src = objImg.src;
   var hRatio;
   var wRatio;
   var Ratio = 1;
-  var w = img.width;
-  var h = img.height;
+  var w = objImg.naturalWidth || objImg.width;
+  var h = objImg.naturalHeight || objImg.height;
+
+  if (!w || !h) {
+    return;
+  }
+
   wRatio = maxWidth / w;
   hRatio = maxHeight / h;
-  if (maxWidth == 0 && maxHeight == 0) {
+  if (maxWidth === 0 && maxHeight === 0) {
     Ratio = 1;
-  } else if (maxWidth == 0) {//
+  } else if (maxWidth === 0) {
     if (hRatio < 1) Ratio = hRatio;
-  } else if (maxHeight == 0) {
+  } else if (maxHeight === 0) {
     if (wRatio < 1) Ratio = wRatio;
   } else if (wRatio < 1 || hRatio < 1) {
     Ratio = (wRatio <= hRatio ? wRatio : hRatio);
   }
-  // if (Ratio < 1) {
-    w = w * Ratio;
-    h = h * Ratio;
-  // }
+
+  w = w * Ratio;
+  h = h * Ratio;
+
   objImg.height = h;
   objImg.width = w;
 }

--- a/html/topic.js
+++ b/html/topic.js
@@ -13,12 +13,21 @@ vsPostMessage('setTitle', {
   title: document.title
 });
 
+function normalizeNGAImageUrl(url) {
+  if (!url) {
+    return url;
+  }
+  return url
+    .replace('://img.nga.178.com', '://img.nga.cn')
+    .replace('://img4.nga.178.com', '://img4.nga.cn');
+}
+
 // 无图模式：点击占位加载当前图片
 document.querySelectorAll('.nga-img-placeholder').forEach((el) => {
   el.style.cursor = 'pointer';
   el.title = '点击加载图片';
   el.onclick = () => {
-    const src = el.dataset['src'];
+    const src = normalizeNGAImageUrl(el.dataset['src']);
     if (!src) {
       return;
     }
@@ -36,6 +45,11 @@ document.querySelectorAll('.nga-img-placeholder').forEach((el) => {
 
 // 给图片添加查看图片的功能
 document.querySelectorAll('img').forEach((img) => {
+  const normalizedSrc = normalizeNGAImageUrl(img.src);
+  if (normalizedSrc && normalizedSrc !== img.src) {
+    img.src = normalizedSrc;
+  }
+
   img.onload = () => {
     // if (img.width < 100 && img.height < 100) {
     //   return;
@@ -55,7 +69,7 @@ document.querySelectorAll('img').forEach((img) => {
 const supportImageTypes = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
 supportImageTypes.forEach((type) => {
   document.querySelectorAll(`.topic-content a[href$=".${type}"]`).forEach((a) => {
-    a.dataset['imageSrc'] = a.href;
+    a.dataset['imageSrc'] = normalizeNGAImageUrl(a.href);
     // vsc中 return false 不能阻止a标签跳转。曲线救国
     a.href = 'javascript:;';
     a.onclick = () => {
@@ -107,28 +121,31 @@ function onSubmit() {
 }
 
 function AutoResizeImage(maxWidth, maxHeight, objImg) {
-  var img = new Image();
-  img.src = objImg.src;
   var hRatio;
   var wRatio;
   var Ratio = 1;
-  var w = img.width;
-  var h = img.height;
+  var w = objImg.naturalWidth || objImg.width;
+  var h = objImg.naturalHeight || objImg.height;
+
+  if (!w || !h) {
+    return;
+  }
+
   wRatio = maxWidth / w;
   hRatio = maxHeight / h;
-  if (maxWidth == 0 && maxHeight == 0) {
+  if (maxWidth === 0 && maxHeight === 0) {
     Ratio = 1;
-  } else if (maxWidth == 0) {//
+  } else if (maxWidth === 0) {
     if (hRatio < 1) Ratio = hRatio;
-  } else if (maxHeight == 0) {
+  } else if (maxHeight === 0) {
     if (wRatio < 1) Ratio = wRatio;
   } else if (wRatio < 1 || hRatio < 1) {
     Ratio = (wRatio <= hRatio ? wRatio : hRatio);
   }
-  // if (Ratio < 1) {
-    w = w * Ratio;
-    h = h * Ratio;
-  // }
+
+  w = w * Ratio;
+  h = h * Ratio;
+
   objImg.height = h;
   objImg.width = w;
 }

--- a/src/nga.ts
+++ b/src/nga.ts
@@ -242,7 +242,7 @@ export class NGA {
     }    
     static buildLiteInput(data: string): string {
         let r = prepareNgaLiteJsRaw(data);
-        r = r.replace(/\[img\]\./g, '<img style=\\"background-color: #FFFAFA\\" src=\\"https://img.nga.178.com/attachments')
+        r = r.replace(/\[img\]\./g, '<img style=\\"background-color: #FFFAFA\\" src=\\"https://img.nga.cn/attachments')
             .replace(/\[\/img\]/g, '\\">')
             .replace(/\[img\]/g, '<img style=\\"background-color: #FFFAFA\\" src=\\"')
             .replace(/\[url\]/g, '<a href=\\"')

--- a/src/process/smile.ts
+++ b/src/process/smile.ts
@@ -223,35 +223,35 @@ export function processSmile(content: string): string {
     let rex = content.match(/\[s\:ac\:.+?\]/g);
     if (rex !== null) {
         for (let i=0; i<rex.length; i++) {
-            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.178.com/ngabbs/post/smile/${(smile_ac as Dict)[rex[i].replace('[s:ac:', '').replace(']', '')]}">`);
+            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.cn/ngabbs/post/smile/${(smile_ac as Dict)[rex[i].replace('[s:ac:', '').replace(']', '')]}">`);
         }
     }
 
     rex = content.match(/\[s\:a2\:.+?\]/g);
     if (rex !== null) {
         for (let i=0; i<rex.length; i++) {
-            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.178.com/ngabbs/post/smile/${(smile_a2 as Dict)[rex[i].replace('[s:a2:', '').replace(']', '')]}">`);
+            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.cn/ngabbs/post/smile/${(smile_a2 as Dict)[rex[i].replace('[s:a2:', '').replace(']', '')]}">`);
         }
     }
 
     rex = content.match(/\[s\:pst\:.+?\]/g);
     if (rex !== null) {
         for (let i=0; i<rex.length; i++) {
-            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.178.com/ngabbs/post/smile/${(smile_pst as Dict)[rex[i].replace('[s:pst:', '').replace(']', '')]}">`);
+            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.cn/ngabbs/post/smile/${(smile_pst as Dict)[rex[i].replace('[s:pst:', '').replace(']', '')]}">`);
         }
     }
 
     rex = content.match(/\[s\:dt\:.+?\]/g);
     if (rex !== null) {
         for (let i=0; i<rex.length; i++) {
-            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.178.com/ngabbs/post/smile/${(smile_dt as Dict)[rex[i].replace('[s:dt:', '').replace(']', '')]}">`);
+            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.cn/ngabbs/post/smile/${(smile_dt as Dict)[rex[i].replace('[s:dt:', '').replace(']', '')]}">`);
         }
     }
 
     rex = content.match(/\[s\:pg\:.+?\]/g);
     if (rex !== null) {
         for (let i=0; i<rex.length; i++) {
-            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.178.com/ngabbs/post/smile/${(smile_pg as Dict)[rex[i].replace('[s:pg:', '').replace(']', '')]}">`);
+            content = content.replace(rex[i], `<img style="background-color: #FFFAFA" src="https://img4.nga.cn/ngabbs/post/smile/${(smile_pg as Dict)[rex[i].replace('[s:pg:', '').replace(']', '')]}">`);
         }
     }
 


### PR DESCRIPTION
img.nga.178.com 和 img4.nga.178.com 的 DNS 记录已不存在，导致所有图片加载失败。 将源码中所有硬编码的旧域名替换为 img.nga.cn / img4.nga.cn。
在 topic.js / topic-spic.js 中增加运行时 URL 归一化，修复已渲染内容中残留的旧域名链接。

同时修复 AutoResizeImage 错误读取图片尺寸的问题：
原实现用 new Image() 同步读宽高，始终得到 0x0，导致图片被强制缩成不可见。
改为直接读取已加载元素的 naturalWidth/naturalHeight。