### PR TITLE
方便长楼进行爬楼，重新优化了分页组件，支持跳转和省略中间行。

### DIFF
--- a/docs/superpowers/plans/2026-08-18-topic-pagination.md
+++ b/docs/superpowers/plans/2026-08-18-topic-pagination.md
@@ -1,0 +1,460 @@
+# 帖子页分页组件改造 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 NGA-MoFish 帖子详情页的平铺分页改为“页码窗口 + 省略号 + 输入跳转 + 刷新”的统一组件，并同时出现在回帖区上方与回复列表下方。
+
+**Architecture:** 纯前端 webview 改动。两个 art-template 模板（`html/topic.html` 普通模式、`html/topic-spic.html` 表情小图模式）各渲染两份同一标记的分页组件（顶部 + 底部）；页码窗口在模板 `<% %>` 内计算；跳转与刷新复用已有的 `pageTurning` / `refresh` 消息。样式追加到 `html/topic-themes.css`（普通主题与 terminal 主题两段）。不修改任何 TypeScript 代码。
+
+**Tech Stack:** art-template（模板内 `<% %>` / `<%= %>` / `<%- %>` 原生语法）、原生 HTML/CSS/JS（webview）、mocha + assert（模板渲染回归测试，直跑不依赖 VS Code）。
+
+## Global Constraints
+
+- 显示条件固定为 `{{if !topic.onlyAuthor && topic.pages > 1}}`；只看楼主与单页帖子不渲染分页。
+- 页码窗口规则：总页数 ≤ 7 全部显示；否则显示 `1 … (pageNow-2..pageNow+2) … N`，空缺处用 `<span class="page-ellipsis">…</span>`。
+- 上一页/下一页始终渲染；第 1 页时上一页加 `is-disabled`，末页时下一页加 `is-disabled`，禁用态不输出 onclick。
+- 刷新按钮：`onclick="vsPostMessage('refresh', {page: <%- topic.pageNow %>});"`，标题 `刷新当前页面`。
+- 跳转：输入框（class `page-jump-input`，`type="number"`，`min=1`，`max=topic.pages`，`value=topic.pageNow`）+ 跳转按钮（class `page-jump-btn`，`onclick="jumpToPage(this)"`），输入框支持回车。
+- **模板沙箱内不可用全局对象（如 `Math`）**：窗口计算必须只用运算符与三元表达式，不要写 `Math.max` / `Math.min` / `parseInt`。
+- 两处组件标记必须完全一致（同一段代码复制两份）。
+- 沿用现有 `.pages` 容器与 `.pageUp/.pageDown/.pages a/.pages b` 样式；新增类名：`page-ellipsis`、`is-disabled`、`page-refresh`、`page-jump`、`page-jump-input`、`page-jump-btn`。
+- 样式必须同时补到普通主题段与 `body[data-topic-theme="terminal"]` 段。
+- 不新增依赖、不修改 TS 源码、不修改 `topic.less`。
+- 测试直跑命令：`npx mocha --ui tdd out/test/suite/<测试文件>.js`（不需要 vscode-test / 下载 VS Code）。
+
+---
+
+### Task 1: topic.html 分页组件（测试 + 模板 + 样式 + 跳转逻辑）
+
+**Files:**
+- Create: `src/test/suite/topicPagination.test.ts`
+- Modify: `html/topic.html`（顶部：第 114 行 `<hr />` 与第 116 行 `<section class="reply-composer">` 之间插入；底部：替换第 256-276 行旧分页块）
+- Modify: `html/topic-themes.css`（第 404-432 行 `.topic-toolbar, .pages` 段落之后；第 863-868 行 terminal 段落之后）
+- Modify: `html/topic.js`（第 112 行 `function onSubmit()` 之前插入 `jumpToPage`）
+
+**Interfaces:**
+- Produces: `jumpToPage(el)` 全局函数（从点击元素向上找到 `.pages` 容器并读取 `.page-jump-input`，夹取到 [1, max] 后发送 `pageTurning`）；渲染产物包含两处 `class="pages"`、两处 `page-refresh`、两处 `page-jump-input`、当前页 `<b>N</b>`、省略号 `<span class="page-ellipsis">`。
+- Consumes: 模板数据 `topic.onlyAuthor`、`topic.pages`、`topic.pageNow`；消息 `pageTurning` / `refresh`（已在 `src/commands/topicItemClick.ts` 处理，本任务不改）。
+
+- [ ] **Step 1: 创建测试文件**
+
+创建 `src/test/suite/topicPagination.test.ts`，内容如下（覆盖：窗口/省略号/当前页/刷新/跳转出现次数、首页与末页禁用、少页无省略号、只看楼主与单页隐藏）：
+
+```ts
+import * as assert from 'assert';
+import * as path from 'path';
+const template = require('art-template');
+
+function buildTopic(overrides: any = {}): any {
+  return {
+    id: 47324782,
+    title: '测试帖子',
+    node: { title: '版块', name: 'fid' },
+    user: { uid: '1', userNmae: '楼主', labels: [] },
+    displayTime: '2026-08-18 00:00',
+    content: '正文内容',
+    likes: 0,
+    replyCount: 100,
+    replies: [],
+    comments: [],
+    onlyAuthor: false,
+    pageNow: 6,
+    needTurn: true,
+    pages: 30,
+    ...overrides
+  };
+}
+
+function buildData(topic: any): any {
+  return {
+    topic,
+    contextPath: '.',
+    titleHeadingClass: 'topic-title-h1',
+    topicTheme: 'editor',
+    topicJson: JSON.stringify(topic),
+    smilesJson: '{}',
+    replyTargetsJson: '{}'
+  };
+}
+
+function renderTemplate(templateName: string, topic: any): string {
+  const templatePath = path.join(__dirname, '..', '..', '..', 'html', templateName);
+  return template(templatePath, buildData(topic));
+}
+
+function assertPaginationRendered(html: string): void {
+  assert.strictEqual((html.match(/class="pages"/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-ellipsis/g) || []).length, 2);
+  assert.strictEqual((html.match(/<b>6<\/b>/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-refresh/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-jump-input/g) || []).length, 2);
+  assert.strictEqual(html.includes('第30页'), false);
+}
+
+suite('帖子页分页组件 topic.html', () => {
+  test('第6页/共30页渲染页码窗口、省略号、刷新与跳转', () => {
+    const html = renderTemplate('topic.html', buildTopic());
+    assertPaginationRendered(html);
+  });
+
+  test('首页禁用上一页、末页禁用下一页', () => {
+    const first = renderTemplate('topic.html', buildTopic({ pageNow: 1 }));
+    assert.strictEqual((first.match(/pageUp is-disabled/g) || []).length, 2);
+    assert.strictEqual((first.match(/pageDown is-disabled/g) || []).length, 0);
+
+    const last = renderTemplate('topic.html', buildTopic({ pageNow: 30 }));
+    assert.strictEqual((last.match(/pageDown is-disabled/g) || []).length, 2);
+    assert.strictEqual((last.match(/pageUp is-disabled/g) || []).length, 0);
+  });
+
+  test('页数少时无省略号且当前页高亮', () => {
+    const html = renderTemplate('topic.html', buildTopic({ pageNow: 2, pages: 3 }));
+    assert.strictEqual((html.match(/page-ellipsis/g) || []).length, 0);
+    assert.strictEqual((html.match(/<b>2<\/b>/g) || []).length, 2);
+  });
+
+  test('只看楼主与单页帖子不渲染分页', () => {
+    const onlyAuthor = renderTemplate('topic.html', buildTopic({ onlyAuthor: true }));
+    assert.strictEqual((onlyAuthor.match(/class="pages"/g) || []).length, 0);
+
+    const singlePage = renderTemplate('topic.html', buildTopic({ pageNow: 1, pages: 1 }));
+    assert.strictEqual((singlePage.match(/class="pages"/g) || []).length, 0);
+  });
+});
+```
+
+- [ ] **Step 2: 编译并运行测试，确认失败**
+
+Run:
+```bash
+npm run compile
+npx mocha --ui tdd out/test/suite/topicPagination.test.js
+```
+Expected: FAIL。当前 `topic.html` 只有底部 1 个 `class="pages"`，且没有 `page-ellipsis` / `page-refresh` / `page-jump-input`，也没有 `<b>6</b>`（现为 `<b>第6页</b>`）。
+
+- [ ] **Step 3: 在 topic.html 顶部插入分页组件**
+
+在 `html/topic.html` 第 114 行 `<hr />` 与第 116 行 `<section class="reply-composer" id="replyComposer" ...>` 之间插入（保持两行缩进对齐）:
+
+```html
+    <!-- 分页（顶部） -->
+    {{if !topic.onlyAuthor && topic.pages > 1}}
+    <div class="pages">
+      <% if (topic.pageNow > 1) { %>
+      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow - 1 %>});" title="上一页">上一页</a>
+      <% } else { %>
+      <a class="pageUp is-disabled" href="javascript:;" title="上一页">上一页</a>
+      <% } %>
+      <%
+        var pageList = [];
+        if (topic.pages <= 7) {
+          for (var i = 1; i <= topic.pages; i++) pageList.push(i);
+        } else {
+          pageList.push(1);
+          var start = (topic.pageNow - 2 > 2) ? topic.pageNow - 2 : 2;
+          var end = (topic.pageNow + 2 < topic.pages - 1) ? topic.pageNow + 2 : topic.pages - 1;
+          if (start > 2) pageList.push(0);
+          for (var i = start; i <= end; i++) pageList.push(i);
+          if (end < topic.pages - 1) pageList.push(0);
+          pageList.push(topic.pages);
+        }
+      %>
+      <% for (var j = 0; j < pageList.length; j++) {
+        var p = pageList[j];
+        if (p === 0) { %>
+          <span class="page-ellipsis">…</span>
+        <% } else if (p === topic.pageNow) { %>
+          <b><%- p %></b>
+        <% } else { %>
+          <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- p %>});"><%- p %></a>
+        <% } %>
+      <% } %>
+      <% if (topic.pageNow < topic.pages) { %>
+      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow + 1 %>});" title="下一页">下一页</a>
+      <% } else { %>
+      <a class="pageDown is-disabled" href="javascript:;" title="下一页">下一页</a>
+      <% } %>
+      <a class="page-refresh" href="javascript:;" onclick="vsPostMessage('refresh', {page: <%= topic.pageNow %>});" title="刷新当前页面">刷新</a>
+      <span class="page-jump">跳至 <input class="page-jump-input" type="number" min="1" max="<%= topic.pages %>" value="<%= topic.pageNow %>" onkeydown="if (event.key === 'Enter') jumpToPage(this);" /> 页 <button type="button" class="page-jump-btn" onclick="jumpToPage(this)">跳转</button></span>
+    </div>
+    {{/if}}
+```
+
+- [ ] **Step 4: 替换 topic.html 底部旧分页块**
+
+把 `html/topic.html` 第 256-276 行整块（`{{if !topic.onlyAuthor && topic.needTurn}}` 到第二个 `{{/if}}`，含 `.pageUp/.pageDown` 链接与平铺 `.pages`）替换为与 Step 3 完全相同的组件块（注释改为 `<!-- 分页（底部） -->`，其余逐字一致）。注意：旧块中的 `<hr />`（第 263 行）一并删除，不要保留。
+
+- [ ] **Step 5: 追加样式到 topic-themes.css**
+
+在 `html/topic-themes.css` 第 432 行 `.topic-toolbar a:hover, .pageUp:hover, .pageDown:hover, .pages a:hover { background: var(--mofish-hover); }` 之后追加：
+
+```css
+.pages .page-ellipsis {
+  padding: 2px 4px;
+  color: var(--mofish-muted);
+}
+
+.pages .is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.pages .page-refresh,
+.pages .page-jump button {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--mofish-border);
+  border-radius: 2px;
+  color: var(--mofish-editor-fg);
+  background: var(--mofish-panel-bg);
+  font-size: 12px;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.pages .page-jump {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--mofish-muted);
+  font-size: 12px;
+}
+
+.pages .page-jump input {
+  width: 56px;
+  height: 24px;
+  padding: 2px 6px;
+  border: 1px solid var(--mofish-border);
+  border-radius: 2px;
+  box-sizing: border-box;
+  background: var(--mofish-panel-bg);
+  color: var(--mofish-editor-fg);
+  font-size: 12px;
+}
+
+.pages .page-jump input:focus {
+  outline: none;
+  border-color: var(--vscode-focusBorder);
+}
+```
+
+再在 terminal 主题段（第 868 行 `.pages b { border-style: dashed; ... }` 之后）追加：
+
+```css
+body[data-topic-theme="terminal"] .pages .page-refresh,
+body[data-topic-theme="terminal"] .pages .page-jump button,
+body[data-topic-theme="terminal"] .pages .page-jump input {
+  border-style: dashed;
+  background: transparent;
+  font-family: var(--mofish-mono);
+}
+```
+
+- [ ] **Step 6: 在 topic.js 添加 jumpToPage**
+
+在 `html/topic.js` 第 112 行 `function onSubmit() {` 之前插入：
+
+```js
+// 分页跳转：读取当前组件输入框页码并夹取到合法范围
+function jumpToPage(el) {
+  const container = el.closest('.pages');
+  if (!container) {
+    return;
+  }
+  const input = container.querySelector('.page-jump-input');
+  if (!input || !input.value.trim()) {
+    return;
+  }
+  const page = parseInt(input.value, 10);
+  if (isNaN(page)) {
+    return;
+  }
+  const max = parseInt(input.max, 10) || 1;
+  const clamped = Math.min(Math.max(page, 1), max);
+  input.value = clamped;
+  vsPostMessage('pageTurning', { page: clamped });
+}
+```
+
+- [ ] **Step 7: 重新编译并运行测试，确认通过**
+
+Run:
+```bash
+npm run compile
+npx mocha --ui tdd out/test/suite/topicPagination.test.js
+```
+Expected: 4 tests PASS。
+
+- [ ] **Step 8: 运行 lint**
+
+Run:
+```bash
+npm run lint
+```
+Expected: 无错误。
+
+- [ ] **Step 9: 手动验证（VSCode 扩展开发宿主 F5）**
+
+逐项检查：
+1. 打开一个总页数 > 7 的帖子：顶部（回帖编辑框上方）与底部各出现一组完整分页。
+2. 第 6 页左右显示 `1 … 4 5 6 7 8 … N`，当前页加粗高亮，无平铺的“第1页…第N页”。
+3. 第 1 页时“上一页”置灰不可点；末页时“下一页”置灰。
+4. 输入页码点“跳转”或按回车正确翻页；输入 999 跳到末页，输入 0 / 负数跳到第 1 页。
+5. 点“刷新”重新加载当前页。
+6. 点“只看楼主”后分页隐藏。
+7. editor / source / terminal 三套主题下组件样式正常（无错位、输入框可聚焦）。
+
+- [ ] **Step 10: 提交**
+
+```bash
+git add html/topic.html html/topic-themes.css html/topic.js src/test/suite/topicPagination.test.ts
+git commit -m "feat: 帖子页分页改为页码窗口+跳转+刷新 (topic.html)"
+```
+
+---
+
+### Task 2: topic-spic.html 同步分页组件
+
+**Files:**
+- Modify: `src/test/suite/topicPagination.test.ts`（追加 spic 模板测试）
+- Modify: `html/topic-spic.html`（顶部：第 108 行 `<hr />` 与第 110 行 `<section class="reply-composer">` 之间插入；底部：替换第 250-270 行旧分页块）
+- Modify: `html/topic-spic.js`（第 121 行 `function onSubmit()` 之前插入 `jumpToPage`）
+
+**Interfaces:**
+- Consumes: Task 1 已加入的 `buildTopic()` / `buildData()` / `renderTemplate()` / `assertPaginationRendered()` 辅助函数（在同一测试文件中）。
+- Produces: `topic-spic.html` 渲染产物与 `topic.html` 一致（两处 `class="pages"` 等）；`topic-spic.js` 提供同名 `jumpToPage(el)`。
+
+- [ ] **Step 1: 追加 spic 模板测试**
+
+在 `src/test/suite/topicPagination.test.ts` 末尾（现有 suite 闭合后）追加：
+
+```ts
+suite('帖子页分页组件 topic-spic.html', () => {
+  test('与 topic.html 渲染一致', () => {
+    const html = renderTemplate('topic-spic.html', buildTopic());
+    assertPaginationRendered(html);
+  });
+
+  test('只看楼主不渲染分页', () => {
+    const onlyAuthor = renderTemplate('topic-spic.html', buildTopic({ onlyAuthor: true }));
+    assert.strictEqual((onlyAuthor.match(/class="pages"/g) || []).length, 0);
+  });
+});
+```
+
+- [ ] **Step 2: 编译并运行测试，确认失败**
+
+Run:
+```bash
+npm run compile
+npx mocha --ui tdd out/test/suite/topicPagination.test.js
+```
+Expected: 新增的 2 个 spic 测试 FAIL（`topic-spic.html` 仍是旧平铺分页），原有 4 个 topic.html 测试仍 PASS。
+
+- [ ] **Step 3: 在 topic-spic.html 顶部插入分页组件**
+
+在 `html/topic-spic.html` 第 108 行 `<hr />` 与第 110 行 `<section class="reply-composer" id="replyComposer" ...>` 之间插入：
+
+```html
+    <!-- 分页（顶部） -->
+    {{if !topic.onlyAuthor && topic.pages > 1}}
+    <div class="pages">
+      <% if (topic.pageNow > 1) { %>
+      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow - 1 %>});" title="上一页">上一页</a>
+      <% } else { %>
+      <a class="pageUp is-disabled" href="javascript:;" title="上一页">上一页</a>
+      <% } %>
+      <%
+        var pageList = [];
+        if (topic.pages <= 7) {
+          for (var i = 1; i <= topic.pages; i++) pageList.push(i);
+        } else {
+          pageList.push(1);
+          var start = (topic.pageNow - 2 > 2) ? topic.pageNow - 2 : 2;
+          var end = (topic.pageNow + 2 < topic.pages - 1) ? topic.pageNow + 2 : topic.pages - 1;
+          if (start > 2) pageList.push(0);
+          for (var i = start; i <= end; i++) pageList.push(i);
+          if (end < topic.pages - 1) pageList.push(0);
+          pageList.push(topic.pages);
+        }
+      %>
+      <% for (var j = 0; j < pageList.length; j++) {
+        var p = pageList[j];
+        if (p === 0) { %>
+          <span class="page-ellipsis">…</span>
+        <% } else if (p === topic.pageNow) { %>
+          <b><%- p %></b>
+        <% } else { %>
+          <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- p %>});"><%- p %></a>
+        <% } %>
+      <% } %>
+      <% if (topic.pageNow < topic.pages) { %>
+      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow + 1 %>});" title="下一页">下一页</a>
+      <% } else { %>
+      <a class="pageDown is-disabled" href="javascript:;" title="下一页">下一页</a>
+      <% } %>
+      <a class="page-refresh" href="javascript:;" onclick="vsPostMessage('refresh', {page: <%= topic.pageNow %>});" title="刷新当前页面">刷新</a>
+      <span class="page-jump">跳至 <input class="page-jump-input" type="number" min="1" max="<%= topic.pages %>" value="<%= topic.pageNow %>" onkeydown="if (event.key === 'Enter') jumpToPage(this);" /> 页 <button type="button" class="page-jump-btn" onclick="jumpToPage(this)">跳转</button></span>
+    </div>
+    {{/if}}
+```
+
+- [ ] **Step 4: 替换 topic-spic.html 底部旧分页块**
+
+把 `html/topic-spic.html` 第 250-270 行整块替换为与顶部相同的组件块（注释 `<!-- 分页（底部） -->`）。旧块中的 `<hr />`（第 257 行）一并删除。
+
+- [ ] **Step 5: 在 topic-spic.js 添加 jumpToPage**
+
+在 `html/topic-spic.js` 第 121 行 `function onSubmit() {` 之前插入（该文件顶部已有 `vsPostMessage` 定义，直接可用）：
+
+```js
+// 分页跳转：读取当前组件输入框页码并夹取到合法范围
+function jumpToPage(el) {
+  const container = el.closest('.pages');
+  if (!container) {
+    return;
+  }
+  const input = container.querySelector('.page-jump-input');
+  if (!input || !input.value.trim()) {
+    return;
+  }
+  const page = parseInt(input.value, 10);
+  if (isNaN(page)) {
+    return;
+  }
+  const max = parseInt(input.max, 10) || 1;
+  const clamped = Math.min(Math.max(page, 1), max);
+  input.value = clamped;
+  vsPostMessage('pageTurning', { page: clamped });
+}
+```
+
+- [ ] **Step 6: 重新编译并运行测试，确认全部通过**
+
+Run:
+```bash
+npm run compile
+npx mocha --ui tdd out/test/suite/topicPagination.test.js
+```
+Expected: 6 tests 全部 PASS。
+
+- [ ] **Step 7: 运行 lint**
+
+Run:
+```bash
+npm run lint
+```
+Expected: 无错误。
+
+- [ ] **Step 8: 手动验证**
+
+在扩展设置里打开“表情模式/小图模式”（对应 `Global.getStickerMode()` 开关），重复 Task 1 Step 9 的检查清单 1-7，确认 `topic-spic.html` 表现一致。
+
+- [ ] **Step 9: 提交**
+
+```bash
+git add html/topic-spic.html html/topic-spic.js src/test/suite/topicPagination.test.ts
+git commit -m "feat: 表情模式帖子页同步分页组件 (topic-spic.html)"
+```

--- a/docs/superpowers/plans/2026-08-18-topic-pagination.md
+++ b/docs/superpowers/plans/2026-08-18-topic-pagination.md
@@ -84,7 +84,7 @@ function renderTemplate(templateName: string, topic: any): string {
 
 function assertPaginationRendered(html: string): void {
   assert.strictEqual((html.match(/class="pages"/g) || []).length, 2);
-  assert.strictEqual((html.match(/page-ellipsis/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-ellipsis/g) || []).length, 4);
   assert.strictEqual((html.match(/<b>6<\/b>/g) || []).length, 2);
   assert.strictEqual((html.match(/page-refresh/g) || []).length, 2);
   assert.strictEqual((html.match(/page-jump-input/g) || []).length, 2);

--- a/docs/superpowers/specs/2026-08-18-topic-pagination-design.md
+++ b/docs/superpowers/specs/2026-08-18-topic-pagination-design.md
@@ -1,0 +1,98 @@
+# 帖子页分页组件改造设计
+
+日期：2026-08-18
+状态：待用户复核
+
+## 背景与目标
+
+NGA-MoFish 扩展的帖子详情页（webview）目前把分页拆成两部分展示：底部一组“上一页/下一页”链接，以及一段把所有页码平铺渲染的 `.pages`（第1页…第N页）。当帖子页数多时，平铺页码很长、很占空间；且顶部没有分页，浏览回复需要滚到底部才能翻页。
+
+本次改造目标：
+
+1. 分页改为“页码窗口 + 省略号 + 输入跳转”的紧凑形态。
+2. 在回帖区域上方（编辑框之前）增加同一组分页。
+3. 在上一页/下一页按钮右侧增加刷新页面按钮。
+
+## 现状
+
+- 模板：`html/topic.html`、`html/topic-spic.html`（表情小图模式）都包含：
+  - `{{if !topic.onlyAuthor && topic.needTurn}}` 下的 `.pageUp` / `.pageDown` 链接（第1页只显示下一页，末页只显示上一页）。
+  - `{{if !topic.onlyAuthor}}` 下的 `.pages` 平铺循环：`<% for(var i = 1; i <= topic.pages; i++){ %>`。
+- 样式：`.pages`、`.pageUp`、`.pageDown`、`.pages a`、`.pages b` 在 `html/topic-themes.css` 中定义，普通主题与 terminal 主题两段都有；`html/topic.less` 中的 `.page` 类未被模板使用。
+- 消息：`pageTurning`（切页）与 `refresh`（刷新当前页）在 `src/commands/topicItemClick.ts` 已有处理，可直接复用。
+- 数据：`TopicDetail` 提供 `pages`（总页数）、`pageNow`（当前页）、`onlyAuthor`（只看楼主）、`needTurn`（是否还需翻页）。
+
+## 设计
+
+### 组件结构（顶部/底部同一份标记）
+
+```
+<div class="pages">
+  <a class="pageUp">上一页</a>
+  <a>1</a><span class="page-ellipsis">…</span><a>4</a><a>5</a><b>6</b><a>7</a><a>8</a><span class="page-ellipsis">…</span><a>30</a>
+  <a class="pageDown">下一页</a>
+  <a class="page-refresh" title="刷新当前页面">刷新</a>
+  <span class="page-jump">跳至 <input type="number" min="1" max="30" /> 页 <button>跳转</button></span>
+</div>
+```
+
+- 页码窗口算法（在 art-template `<% %>` 内计算，生成 `pageList` 数组供 `{{each}}` 渲染）：
+  - 总页数 ≤ 7：显示 1..pages 全部。
+  - 否则：显示 1、(pageNow-2..pageNow+2)、pages；中间空缺用省略号占位。
+  - 当前页渲染为 `<b>`，其余为 `<a>`。
+- 上一页/下一页始终渲染；第 1 页时上一页置灰禁用，末页时下一页置灰禁用（`is-disabled` 类，无点击行为）。原“边界隐藏”行为废除，保证按钮与刷新位置稳定。
+- 刷新：`vsPostMessage('refresh', { page: topic.pageNow })`，复用现有 `refresh` 消息。
+- 跳转：输入框支持回车与“跳转”按钮，读取页码并夹取到 1..pages 后发送 `pageTurning`。
+
+### 放置位置
+
+- 顶部：`topic-toolbar` 后的 `<hr />` 与 `<section class="reply-composer">` 之间。
+- 底部：替换现有的 `.pageUp/.pageDown` 块与 `.pages` 平铺块，位于回复列表之后。
+- 显示条件：`{{if !topic.onlyAuthor && topic.pages > 1}}`。只看楼主隐藏；单页帖子不再渲染分页（含“第1页”）。
+
+### 样式
+
+- 沿用 `.pages` 容器（flex、gap 8px）与 `.pageUp/.pageDown/.pages a/.pages b` 现有主题样式。
+- `html/topic-themes.css` 新增：
+  - `.page-ellipsis`：省略号占位样式。
+  - `.is-disabled`：置灰、`pointer-events: none`、无 hover 效果。
+  - `.page-refresh`、`.page-jump input`、`.page-jump button`：与现有分页按钮视觉一致（border、padding、字号 12px、主题变量）。
+- 普通主题段与 `body[data-topic-theme="terminal"]` 段同步补充。
+
+### JavaScript
+
+- `html/topic.js` 与 `html/topic-spic.js` 各新增 `jumpToPage()`：读取分页输入框值 → 数值校验并夹取到 [1, pages] → `vsPostMessage('pageTurning', { page })`。
+- 模板中跳转按钮与输入框通过 `onclick="jumpToPage(this)"`、回车键触发；页面中同时存在顶部/底部两个组件，函数内通过事件元素向上定位到所在 `.pages` 容器再取输入框，避免重复 ID 冲突。
+
+### 错误处理
+
+- 跳转输入非数字或越界：夹取到合法范围；输入为空时不发送。
+- 网络/加载失败：沿用现有 `loadTopicInPanel` 的错误页逻辑，不新增处理。
+
+## 改动文件
+
+- `html/topic.html`
+- `html/topic-spic.html`
+- `html/topic-themes.css`
+- `html/topic.js`
+- `html/topic-spic.js`
+
+不涉及 TypeScript / 后端逻辑改动。
+
+## 验证
+
+1. `npm run compile`（确认扩展编译通过；本方案不改 TS，但作为回归检查）。
+2. VSCode 扩展开发宿主（F5）手动验证：
+   - 多页帖子：顶部/底部均出现分页组件；页码窗口与省略号正确；当前页高亮。
+   - 第 1 页：上一页禁用；末页：下一页禁用。
+   - 输入跳转（按钮与回车）正确切页；越界值被夹取。
+   - 刷新按钮重新加载当前页。
+   - 只看楼主：分页隐藏。
+   - `topic.html` 与 `topic-spic.html`（设置里切换表情模式）行为一致。
+   - editor / source / terminal 三套主题下样式正常。
+
+## 非目标（Out of scope）
+
+- 不改变 NGA 数据获取、翻页消息或缓存逻辑。
+- 不调整顶部工具栏已有的“刷新页面”链接。
+- 不引入新的依赖或构建步骤。

--- a/html/topic-spic.html
+++ b/html/topic-spic.html
@@ -107,6 +107,48 @@
 
     <hr />
 
+    <!-- 分页（顶部） -->
+    {{if !topic.onlyAuthor && topic.pages > 1}}
+    <div class="pages">
+      <% if (topic.pageNow > 1) { %>
+      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow - 1 %>});" title="上一页">上一页</a>
+      <% } else { %>
+      <a class="pageUp is-disabled" href="javascript:;" title="上一页">上一页</a>
+      <% } %>
+      <%
+        var pageList = [];
+        if (topic.pages <= 7) {
+          for (var i = 1; i <= topic.pages; i++) pageList.push(i);
+        } else {
+          pageList.push(1);
+          var start = (topic.pageNow - 2 > 2) ? topic.pageNow - 2 : 2;
+          var end = (topic.pageNow + 2 < topic.pages - 1) ? topic.pageNow + 2 : topic.pages - 1;
+          if (start > 2) pageList.push(0);
+          for (var i = start; i <= end; i++) pageList.push(i);
+          if (end < topic.pages - 1) pageList.push(0);
+          pageList.push(topic.pages);
+        }
+      %>
+      <% for (var j = 0; j < pageList.length; j++) {
+        var p = pageList[j];
+        if (p === 0) { %>
+          <span class="page-ellipsis">…</span>
+        <% } else if (p === topic.pageNow) { %>
+          <b><%- p %></b>
+        <% } else { %>
+          <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- p %>});"><%- p %></a>
+        <% } %>
+      <% } %>
+      <% if (topic.pageNow < topic.pages) { %>
+      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow + 1 %>});" title="下一页">下一页</a>
+      <% } else { %>
+      <a class="pageDown is-disabled" href="javascript:;" title="下一页">下一页</a>
+      <% } %>
+      <a class="page-refresh" href="javascript:;" onclick="vsPostMessage('refresh', {page: <%= topic.pageNow %>});" title="刷新当前页面">刷新</a>
+      <span class="page-jump">跳至 <input class="page-jump-input" type="number" min="1" max="<%= topic.pages %>" value="<%= topic.pageNow %>" onkeydown="if (event.key === 'Enter') jumpToPage(this);" /> 页 <button type="button" class="page-jump-btn" onclick="jumpToPage(this)">跳转</button></span>
+    </div>
+    {{/if}}
+
     <section class="reply-composer" id="replyComposer" aria-labelledby="replyComposerTitle">
       <div class="reply-composer-heading">
         <div>
@@ -247,25 +289,45 @@
       {{/each}}
     </div>
 
-    {{if !topic.onlyAuthor && topic.needTurn}}
-      {{if topic.pageNow > 1}}
-      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow-1 %>});" title="上一页">上一页</a>
-      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow+1 %>});" title="下一页">下一页</a>
-      {{else}}
-      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow+1 %>});" title="下一页">下一页</a>
-      {{/if}}
-      <hr />
-    {{/if}}
-    
-    {{if !topic.onlyAuthor}}
+    <!-- 分页（底部） -->
+    {{if !topic.onlyAuthor && topic.pages > 1}}
     <div class="pages">
-    <% for(var i = 1; i <= topic.pages; i++){ %>
-      <% if (i == topic.pageNow) {%>
-      <b>第<%- i %>页</b>
-      <%} else {%>
-      <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- i %>});"><%- i %></a>
-      <%}%>
-    <% } %>
+      <% if (topic.pageNow > 1) { %>
+      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow - 1 %>});" title="上一页">上一页</a>
+      <% } else { %>
+      <a class="pageUp is-disabled" href="javascript:;" title="上一页">上一页</a>
+      <% } %>
+      <%
+        var pageList = [];
+        if (topic.pages <= 7) {
+          for (var i = 1; i <= topic.pages; i++) pageList.push(i);
+        } else {
+          pageList.push(1);
+          var start = (topic.pageNow - 2 > 2) ? topic.pageNow - 2 : 2;
+          var end = (topic.pageNow + 2 < topic.pages - 1) ? topic.pageNow + 2 : topic.pages - 1;
+          if (start > 2) pageList.push(0);
+          for (var i = start; i <= end; i++) pageList.push(i);
+          if (end < topic.pages - 1) pageList.push(0);
+          pageList.push(topic.pages);
+        }
+      %>
+      <% for (var j = 0; j < pageList.length; j++) {
+        var p = pageList[j];
+        if (p === 0) { %>
+          <span class="page-ellipsis">…</span>
+        <% } else if (p === topic.pageNow) { %>
+          <b><%- p %></b>
+        <% } else { %>
+          <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- p %>});"><%- p %></a>
+        <% } %>
+      <% } %>
+      <% if (topic.pageNow < topic.pages) { %>
+      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow + 1 %>});" title="下一页">下一页</a>
+      <% } else { %>
+      <a class="pageDown is-disabled" href="javascript:;" title="下一页">下一页</a>
+      <% } %>
+      <a class="page-refresh" href="javascript:;" onclick="vsPostMessage('refresh', {page: <%= topic.pageNow %>});" title="刷新当前页面">刷新</a>
+      <span class="page-jump">跳至 <input class="page-jump-input" type="number" min="1" max="<%= topic.pages %>" value="<%= topic.pageNow %>" onkeydown="if (event.key === 'Enter') jumpToPage(this);" /> 页 <button type="button" class="page-jump-btn" onclick="jumpToPage(this)">跳转</button></span>
     </div>
     {{/if}}
 

--- a/html/topic-spic.js
+++ b/html/topic-spic.js
@@ -117,6 +117,26 @@ document.querySelectorAll('.topic-content a[href*="/t/"]').forEach((a) => {
   };
 });
 
+// 分页跳转：读取当前组件输入框页码并夹取到合法范围
+function jumpToPage(el) {
+  const container = el.closest('.pages');
+  if (!container) {
+    return;
+  }
+  const input = container.querySelector('.page-jump-input');
+  if (!input || !input.value.trim()) {
+    return;
+  }
+  const page = parseInt(input.value, 10);
+  if (isNaN(page)) {
+    return;
+  }
+  const max = parseInt(input.max, 10) || 1;
+  const clamped = Math.min(Math.max(page, 1), max);
+  input.value = clamped;
+  vsPostMessage('pageTurning', { page: clamped });
+}
+
 // 评论
 function onSubmit() {
   const content = (document.querySelector('#replyBox').value || '').trim();

--- a/html/topic-themes.css
+++ b/html/topic-themes.css
@@ -433,6 +433,56 @@ hr {
   background: var(--mofish-hover);
 }
 
+.pages .page-ellipsis {
+  padding: 2px 4px;
+  color: var(--mofish-muted);
+}
+
+.pages .is-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.pages .page-refresh,
+.pages .page-jump button {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--mofish-border);
+  border-radius: 2px;
+  color: var(--mofish-editor-fg);
+  background: var(--mofish-panel-bg);
+  font-size: 12px;
+  font-weight: 400;
+  cursor: pointer;
+}
+
+.pages .page-jump {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--mofish-muted);
+  font-size: 12px;
+}
+
+.pages .page-jump input {
+  width: 56px;
+  height: 24px;
+  padding: 2px 6px;
+  border: 1px solid var(--mofish-border);
+  border-radius: 2px;
+  box-sizing: border-box;
+  background: var(--mofish-panel-bg);
+  color: var(--mofish-editor-fg);
+  font-size: 12px;
+}
+
+.pages .page-jump input:focus {
+  outline: none;
+  border-color: var(--vscode-focusBorder);
+}
+
 .editor-statusbar {
   position: sticky;
   z-index: 10;
@@ -865,6 +915,14 @@ body[data-topic-theme="terminal"] .pageUp,
 body[data-topic-theme="terminal"] .pageDown,
 body[data-topic-theme="terminal"] .pages a,
 body[data-topic-theme="terminal"] .pages b {
+  border-style: dashed;
+  background: transparent;
+  font-family: var(--mofish-mono);
+}
+
+body[data-topic-theme="terminal"] .pages .page-refresh,
+body[data-topic-theme="terminal"] .pages .page-jump button,
+body[data-topic-theme="terminal"] .pages .page-jump input {
   border-style: dashed;
   background: transparent;
   font-family: var(--mofish-mono);

--- a/html/topic.html
+++ b/html/topic.html
@@ -113,6 +113,48 @@
 
     <hr />
 
+    <!-- 分页（顶部） -->
+    {{if !topic.onlyAuthor && topic.pages > 1}}
+    <div class="pages">
+      <% if (topic.pageNow > 1) { %>
+      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow - 1 %>});" title="上一页">上一页</a>
+      <% } else { %>
+      <a class="pageUp is-disabled" href="javascript:;" title="上一页">上一页</a>
+      <% } %>
+      <%
+        var pageList = [];
+        if (topic.pages <= 7) {
+          for (var i = 1; i <= topic.pages; i++) pageList.push(i);
+        } else {
+          pageList.push(1);
+          var start = (topic.pageNow - 2 > 2) ? topic.pageNow - 2 : 2;
+          var end = (topic.pageNow + 2 < topic.pages - 1) ? topic.pageNow + 2 : topic.pages - 1;
+          if (start > 2) pageList.push(0);
+          for (var i = start; i <= end; i++) pageList.push(i);
+          if (end < topic.pages - 1) pageList.push(0);
+          pageList.push(topic.pages);
+        }
+      %>
+      <% for (var j = 0; j < pageList.length; j++) {
+        var p = pageList[j];
+        if (p === 0) { %>
+          <span class="page-ellipsis">…</span>
+        <% } else if (p === topic.pageNow) { %>
+          <b><%- p %></b>
+        <% } else { %>
+          <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- p %>});"><%- p %></a>
+        <% } %>
+      <% } %>
+      <% if (topic.pageNow < topic.pages) { %>
+      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow + 1 %>});" title="下一页">下一页</a>
+      <% } else { %>
+      <a class="pageDown is-disabled" href="javascript:;" title="下一页">下一页</a>
+      <% } %>
+      <a class="page-refresh" href="javascript:;" onclick="vsPostMessage('refresh', {page: <%= topic.pageNow %>});" title="刷新当前页面">刷新</a>
+      <span class="page-jump">跳至 <input class="page-jump-input" type="number" min="1" max="<%= topic.pages %>" value="<%= topic.pageNow %>" onkeydown="if (event.key === 'Enter') jumpToPage(this);" /> 页 <button type="button" class="page-jump-btn" onclick="jumpToPage(this)">跳转</button></span>
+    </div>
+    {{/if}}
+
     <section class="reply-composer" id="replyComposer" aria-labelledby="replyComposerTitle">
       <div class="reply-composer-heading">
         <div>
@@ -253,25 +295,45 @@
       {{/each}}
     </div>
 
-    {{if !topic.onlyAuthor && topic.needTurn}}
-      {{if topic.pageNow > 1}}
-      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow-1 %>});" title="上一页">上一页</a>
-      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow+1 %>});" title="下一页">下一页</a>
-      {{else}}
-      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow+1 %>});" title="下一页">下一页</a>
-      {{/if}}
-      <hr />
-    {{/if}}
-    
-    {{if !topic.onlyAuthor}}
+    <!-- 分页（底部） -->
+    {{if !topic.onlyAuthor && topic.pages > 1}}
     <div class="pages">
-    <% for(var i = 1; i <= topic.pages; i++){ %>
-      <% if (i == topic.pageNow) {%>
-      <b>第<%- i %>页</b>
-      <%} else {%>
-      <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- i %>});"><%- i %></a>
-      <%}%>
-    <% } %>
+      <% if (topic.pageNow > 1) { %>
+      <a class="pageUp" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow - 1 %>});" title="上一页">上一页</a>
+      <% } else { %>
+      <a class="pageUp is-disabled" href="javascript:;" title="上一页">上一页</a>
+      <% } %>
+      <%
+        var pageList = [];
+        if (topic.pages <= 7) {
+          for (var i = 1; i <= topic.pages; i++) pageList.push(i);
+        } else {
+          pageList.push(1);
+          var start = (topic.pageNow - 2 > 2) ? topic.pageNow - 2 : 2;
+          var end = (topic.pageNow + 2 < topic.pages - 1) ? topic.pageNow + 2 : topic.pages - 1;
+          if (start > 2) pageList.push(0);
+          for (var i = start; i <= end; i++) pageList.push(i);
+          if (end < topic.pages - 1) pageList.push(0);
+          pageList.push(topic.pages);
+        }
+      %>
+      <% for (var j = 0; j < pageList.length; j++) {
+        var p = pageList[j];
+        if (p === 0) { %>
+          <span class="page-ellipsis">…</span>
+        <% } else if (p === topic.pageNow) { %>
+          <b><%- p %></b>
+        <% } else { %>
+          <a href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%- p %>});"><%- p %></a>
+        <% } %>
+      <% } %>
+      <% if (topic.pageNow < topic.pages) { %>
+      <a class="pageDown" href="javascript:;" onclick="vsPostMessage('pageTurning', {page: <%= topic.pageNow + 1 %>});" title="下一页">下一页</a>
+      <% } else { %>
+      <a class="pageDown is-disabled" href="javascript:;" title="下一页">下一页</a>
+      <% } %>
+      <a class="page-refresh" href="javascript:;" onclick="vsPostMessage('refresh', {page: <%= topic.pageNow %>});" title="刷新当前页面">刷新</a>
+      <span class="page-jump">跳至 <input class="page-jump-input" type="number" min="1" max="<%= topic.pages %>" value="<%= topic.pageNow %>" onkeydown="if (event.key === 'Enter') jumpToPage(this);" /> 页 <button type="button" class="page-jump-btn" onclick="jumpToPage(this)">跳转</button></span>
     </div>
     {{/if}}
 

--- a/html/topic.js
+++ b/html/topic.js
@@ -108,6 +108,26 @@ supportImageTypes.forEach((type) => {
 //   };
 // });
 
+// 分页跳转：读取当前组件输入框页码并夹取到合法范围
+function jumpToPage(el) {
+  const container = el.closest('.pages');
+  if (!container) {
+    return;
+  }
+  const input = container.querySelector('.page-jump-input');
+  if (!input || !input.value.trim()) {
+    return;
+  }
+  const page = parseInt(input.value, 10);
+  if (isNaN(page)) {
+    return;
+  }
+  const max = parseInt(input.max, 10) || 1;
+  const clamped = Math.min(Math.max(page, 1), max);
+  input.value = clamped;
+  vsPostMessage('pageTurning', { page: clamped });
+}
+
 // 评论
 function onSubmit() {
   const content = (document.querySelector('#replyBox').value || '').trim();

--- a/src/test/suite/topicPagination.test.ts
+++ b/src/test/suite/topicPagination.test.ts
@@ -1,0 +1,80 @@
+import * as assert from 'assert';
+import * as path from 'path';
+const template = require('art-template');
+
+function buildTopic(overrides: any = {}): any {
+  return {
+    id: 47324782,
+    title: '测试帖子',
+    node: { title: '版块', name: 'fid' },
+    user: { uid: '1', userNmae: '楼主', labels: [] },
+    displayTime: '2026-08-18 00:00',
+    content: '正文内容',
+    likes: 0,
+    replyCount: 100,
+    replies: [],
+    comments: [],
+    onlyAuthor: false,
+    pageNow: 6,
+    needTurn: true,
+    pages: 30,
+    ...overrides
+  };
+}
+
+function buildData(topic: any): any {
+  return {
+    topic,
+    contextPath: '.',
+    titleHeadingClass: 'topic-title-h1',
+    topicTheme: 'editor',
+    topicJson: JSON.stringify(topic),
+    smilesJson: '{}',
+    replyTargetsJson: '{}'
+  };
+}
+
+function renderTemplate(templateName: string, topic: any): string {
+  const templatePath = path.join(__dirname, '..', '..', '..', 'html', templateName);
+  return template(templatePath, buildData(topic));
+}
+
+function assertPaginationRendered(html: string): void {
+  assert.strictEqual((html.match(/class="pages"/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-ellipsis/g) || []).length, 4);
+  assert.strictEqual((html.match(/<b>6<\/b>/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-refresh/g) || []).length, 2);
+  assert.strictEqual((html.match(/page-jump-input/g) || []).length, 2);
+  assert.strictEqual(html.includes('第30页'), false);
+}
+
+suite('帖子页分页组件 topic.html', () => {
+  test('第6页/共30页渲染页码窗口、省略号、刷新与跳转', () => {
+    const html = renderTemplate('topic.html', buildTopic());
+    assertPaginationRendered(html);
+  });
+
+  test('首页禁用上一页、末页禁用下一页', () => {
+    const first = renderTemplate('topic.html', buildTopic({ pageNow: 1 }));
+    assert.strictEqual((first.match(/pageUp is-disabled/g) || []).length, 2);
+    assert.strictEqual((first.match(/pageDown is-disabled/g) || []).length, 0);
+
+    const last = renderTemplate('topic.html', buildTopic({ pageNow: 30 }));
+    assert.strictEqual((last.match(/pageDown is-disabled/g) || []).length, 2);
+    assert.strictEqual((last.match(/pageUp is-disabled/g) || []).length, 0);
+  });
+
+  test('页数少时无省略号且当前页高亮', () => {
+    const html = renderTemplate('topic.html', buildTopic({ pageNow: 2, pages: 3 }));
+    assert.strictEqual((html.match(/page-ellipsis/g) || []).length, 0);
+    assert.strictEqual((html.match(/<b>2<\/b>/g) || []).length, 2);
+  });
+
+  test('只看楼主与单页帖子不渲染分页', () => {
+    const onlyAuthor = renderTemplate('topic.html', buildTopic({ onlyAuthor: true }));
+    assert.strictEqual((onlyAuthor.match(/class="pages"/g) || []).length, 0);
+
+    const singlePage = renderTemplate('topic.html', buildTopic({ pageNow: 1, pages: 1 }));
+    assert.strictEqual((singlePage.match(/class="pages"/g) || []).length, 0);
+  });
+});

--- a/src/test/suite/topicPagination.test.ts
+++ b/src/test/suite/topicPagination.test.ts
@@ -78,3 +78,15 @@ suite('帖子页分页组件 topic.html', () => {
     assert.strictEqual((singlePage.match(/class="pages"/g) || []).length, 0);
   });
 });
+
+suite('帖子页分页组件 topic-spic.html', () => {
+  test('与 topic.html 渲染一致', () => {
+    const html = renderTemplate('topic-spic.html', buildTopic());
+    assertPaginationRendered(html);
+  });
+
+  test('只看楼主不渲染分页', () => {
+    const onlyAuthor = renderTemplate('topic-spic.html', buildTopic({ onlyAuthor: true }));
+    assert.strictEqual((onlyAuthor.match(/class="pages"/g) || []).length, 0);
+  });
+});


### PR DESCRIPTION
进一些高楼帖子后，每次想从之前看的页数看起非常的不方便，需要拉到最下面，再点击跳转。所以我在回复的上方也增加了页面的跳转，并且增加了一个刷新页面的按钮，方便实时查看跟新。
纯vibe coding。